### PR TITLE
Add documentation for common Auth headers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,34 @@ func TestSome(t *testing.T) {
 }
 ```
 
+## Support for Authentication Schemes
+
+The library provides support for common authentication schemes, i.e.: Basic Authentication, API Token Authentication, Bearer Authentication, Digest Access Authentication.
+All of them are equivalent to manually specifying the "Authorization" header value with the appropriate prefix.
+E.g. `WithBearerToken(wiremock.EqualTo("token123")).` works the same as `WithHeader("Authorization", wiremock.EqualTo("Bearer token123")).`.
+
+### Example of usage
+
+```go
+
+basicAuthStub := wiremock.Get(wiremock.URLPathEqualTo("/basic")).
+    WithBasicAuth("username", "password"). // same as: WithHeader("Authorization", wiremock.EqualTo("Basic dXNlcm5hbWU6cGFzc3dvcmQ=")).
+    WillReturnResponse(wiremock.NewResponse().WithStatus(http.StatusOK))
+
+bearerTokenStub := wiremock.Get(wiremock.URLPathEqualTo("/bearer")).
+    WithBearerToken(wiremock.Matching("^\\S+abc\\S+$")). // same as: WithHeader("Authorization", wiremock.Matching("^Bearer \\S+abc\\S+$")).
+    WillReturnResponse(wiremock.NewResponse().WithStatus(http.StatusOK))
+
+apiTokenStub := wiremock.Get(wiremock.URLPathEqualTo("/token")).
+    WithAuthToken(wiremock.StartsWith("myToken123")). // same as: WithHeader("Authorization", wiremock.StartsWith("Token myToken123")).
+    WillReturnResponse(wiremock.NewResponse().WithStatus(http.StatusOK))
+
+digestAuthStub := wiremock.Get(wiremock.URLPathEqualTo("/digest")).
+    WithDigestAuth(wiremock.Contains("realm")). // same as: WithHeader("Authorization", wiremock.StartsWith("Digest ").And(Contains("realm"))).
+    WillReturnResponse(wiremock.NewResponse().WithStatus(http.StatusOK))
+
+```
+
 ## License
 
 [MIT License](./LICENSE)


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

Follow-up to PR: #27

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Description
The following section was added to the [README.md](https://github.com/AntoniKania/go-wiremock/tree/add-documentation-for-auth-headers-support#readme) file
![image](https://github.com/wiremock/go-wiremock/assets/87483058/7ed84370-787d-4e0a-852d-26c652dabe8b)


## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
