### PR TITLE
Add support to formParameters

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -37,6 +37,8 @@ func TestStubRule_ToJson(t *testing.T) {
 				WithQueryParam("id", Contains("1").And(NotContains("2"))).
 				WithBodyPattern(EqualToJson(`{"meta": "information"}`, IgnoreArrayOrder, IgnoreExtraElements)).
 				WithBodyPattern(Contains("information")).
+				WithFormParameter("form1", EqualTo("value1")).
+				WithFormParameter("form2", Matching("value2")).
 				WithMultipartPattern(
 					NewMultipartPattern().
 						WithName("info").

--- a/request.go
+++ b/request.go
@@ -15,6 +15,7 @@ type Request struct {
 	queryParams          map[string]MatcherInterface
 	cookies              map[string]BasicParamMatcher
 	bodyPatterns         []BasicParamMatcher
+	formParameters       map[string]BasicParamMatcher
 	multipartPatterns    []MultipartPatternInterface
 	basicAuthCredentials *struct {
 		username string
@@ -63,6 +64,15 @@ func (r *Request) WithURLMatched(urlMatcher URLMatcherInterface) *Request {
 // WithBodyPattern adds body pattern to list
 func (r *Request) WithBodyPattern(matcher BasicParamMatcher) *Request {
 	r.bodyPatterns = append(r.bodyPatterns, matcher)
+	return r
+}
+
+// WithFormParameter adds form parameter to list
+func (r *Request) WithFormParameter(name string, matcher BasicParamMatcher) *Request {
+	if r.formParameters == nil {
+		r.formParameters = make(map[string]BasicParamMatcher, 1)
+	}
+	r.formParameters[name] = matcher
 	return r
 }
 
@@ -135,6 +145,9 @@ func (r *Request) MarshalJSON() ([]byte, error) {
 
 	if len(r.bodyPatterns) > 0 {
 		request["bodyPatterns"] = r.bodyPatterns
+	}
+	if len(r.formParameters) > 0 {
+		request["formParameters"] = r.formParameters
 	}
 	if len(r.multipartPatterns) > 0 {
 		request["multipartPatterns"] = r.multipartPatterns

--- a/stub_rule.go
+++ b/stub_rule.go
@@ -81,6 +81,12 @@ func (s *StubRule) WithBodyPattern(matcher BasicParamMatcher) *StubRule {
 	return s
 }
 
+// WithFormParameter adds form parameter and returns *StubRule
+func (s *StubRule) WithFormParameter(param string, matcher BasicParamMatcher) *StubRule {
+	s.request.WithFormParameter(param, matcher)
+	return s
+}
+
 // WithMultipartPattern adds multipart body pattern and returns *StubRule
 func (s *StubRule) WithMultipartPattern(pattern *MultipartPattern) *StubRule {
 	s.request.WithMultipartPattern(pattern)

--- a/testdata/expected-template-scenario.json
+++ b/testdata/expected-template-scenario.json
@@ -26,6 +26,14 @@
         "contains": "information"
       }
     ],
+    "formParameters": {
+      "form1": {
+        "equalTo": "value1"
+      },
+      "form2": {
+        "matches": "value2"
+      }
+    },
     "multipartPatterns": [
       {
         "matchingType": "ANY",


### PR DESCRIPTION
This PR implements the `formParameters` option on the request as specified at https://wiremock.org/docs/request-matching/#request-with-form-parameters

When dealing with `application/x-www-form-urlencoded` POST requests, the `formParameters` option makes the life of developer easier for building assertions on requests.

Example:

```go
Client.StubFor(
	wiremock.Post(wiremock.URLPathEqualTo("/url")).
		WithFormParameter("parameter", wiremock.EqualTo("value")).
		WillReturnResponse(...),
)
```

## References

- https://wiremock.org/docs/request-matching/#request-with-form-parameters

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
