### PR TITLE
Add MustEqualToJson param matcher

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -71,6 +71,12 @@ func TestStubRule_ToJson(t *testing.T) {
 			ExpectedFileName: "expected-template-scenario.json",
 		},
 		{
+			Name: "MustEqualToJson",
+			StubRule: NewStubRule("PATCH", URLMatching("/example")).
+				WithBodyPattern(MustEqualToJson(map[string]interface{}{"meta": "information"}, IgnoreArrayOrder, IgnoreExtraElements)),
+			ExpectedFileName: "must-equal-to-json.json",
+		},
+		{
 			Name: "StubRuleWithBearerToken_StartsWithMatcher",
 			StubRule: Post(URLPathEqualTo("/example")).
 				WithHost(EqualTo("localhost")).

--- a/string_value_matcher.go
+++ b/string_value_matcher.go
@@ -107,6 +107,20 @@ func EqualToJson(param string, equalJsonFlags ...EqualFlag) BasicParamMatcher {
 	return NewStringValueMatcher(ParamEqualToJson, param, flags...)
 }
 
+// MustEqualToJson returns a matcher that matches when the parameter is equal to the specified JSON.
+// This method panics if param cannot be marshaled to JSON.
+func MustEqualToJson(param any, equalJsonFlags ...EqualFlag) BasicParamMatcher {
+	if str, ok := param.(string); ok {
+		return EqualToJson(str, equalJsonFlags...)
+	}
+
+	if jsonParam, err := json.Marshal(param); err != nil {
+		panic(fmt.Sprintf("Unable to marshal parameter to JSON: %v", err))
+	} else {
+		return EqualToJson(string(jsonParam), equalJsonFlags...)
+	}
+}
+
 // MatchingXPath returns a matcher that matches when the parameter matches the specified XPath.
 func MatchingXPath(param string) BasicParamMatcher {
 	return NewStringValueMatcher(ParamMatchesXPath, param)

--- a/stub_rule.go
+++ b/stub_rule.go
@@ -97,7 +97,7 @@ func (s *StubRule) WithMultipartPattern(pattern *MultipartPattern) *StubRule {
 func (s *StubRule) WithAuthToken(tokenMatcher BasicParamMatcher) *StubRule {
 	methodPrefix := "Token "
 	m := addAuthMethodToMatcher(tokenMatcher, methodPrefix)
-	s.WithHeader(authorizationHeader, HasExactly(StartsWith(methodPrefix), m))
+	s.WithHeader(authorizationHeader, StartsWith(methodPrefix).And(m))
 	return s
 }
 
@@ -113,7 +113,7 @@ func (s *StubRule) WithBearerToken(tokenMatcher BasicParamMatcher) *StubRule {
 func (s *StubRule) WithDigestAuth(matcher BasicParamMatcher) *StubRule {
 	methodPrefix := "Digest "
 	m := addAuthMethodToMatcher(matcher, methodPrefix)
-	s.WithHeader(authorizationHeader, HasExactly(StartsWith(methodPrefix), m))
+	s.WithHeader(authorizationHeader, StartsWith(methodPrefix).And(m))
 	return s
 }
 

--- a/testdata/must-equal-to-json.json
+++ b/testdata/must-equal-to-json.json
@@ -1,0 +1,18 @@
+{
+  "uuid": "%s",
+  "id": "%s",
+  "request": {
+    "method": "PATCH",
+    "urlPattern": "/example",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"meta\":\"information\"}",
+        "ignoreArrayOrder" : true,
+        "ignoreExtraElements" : true
+      }
+    ]
+  },
+  "response": {
+    "status": 200
+  }
+}


### PR DESCRIPTION
A method MustEqualToJson has been added, which simplifies working with JSON. It accepts a value of any type, which will be marshalled into a JSON string.

## References

- TODO

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
