### PR TITLE
feat: implement record methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ func TestSome(t *testing.T) {
 }
 ```
 
+Alternatively, you can use `wiremock` to record stubs and play them back:
+
+```go
+wiremockClient.StartRecording("https://my.saas.endpoint.com")
+defer wiremockClient.StopRecording()
+//… do some requests to Wiremock
+//… do some assertions using your Saas' SDK
+```
+
 ## Support for Authentication Schemes
 
 The library provides support for common authentication schemes, i.e.: Basic Authentication, API Token Authentication, Bearer Authentication, Digest Access Authentication.

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 const (
@@ -181,4 +182,53 @@ func (c *Client) DeleteStubByID(id string) error {
 // DeleteStub deletes stub mapping.
 func (c *Client) DeleteStub(s *StubRule) error {
 	return c.DeleteStubByID(s.UUID())
+}
+
+// StartRecording starts a recording.
+func (c *Client) StartRecording(targetBaseUrl string) error {
+	requestBody := fmt.Sprintf(`{"targetBaseUrl":"%s"}`, targetBaseUrl)
+	res, err := http.Post(
+		fmt.Sprintf("%s/%s/recordings/start", c.url, wiremockAdminURN),
+		"application/json",
+		strings.NewReader(requestBody),
+	)
+	if err != nil {
+		return fmt.Errorf("start recording error: %s", err.Error())
+	}
+
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		bodyBytes, err := io.ReadAll(res.Body)
+		if err != nil {
+			return fmt.Errorf("read response error: %s", err.Error())
+		}
+
+		return fmt.Errorf("bad response status: %d, response: %s", res.StatusCode, string(bodyBytes))
+	}
+
+	return err
+}
+
+// StopRecording stops a recording.
+func (c *Client) StopRecording() error {
+	res, err := http.Post(
+		fmt.Sprintf("%s/%s/recordings/stop", c.url, wiremockAdminURN),
+		"application/json",
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("stop recording error: %s", err.Error())
+	}
+
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		bodyBytes, err := io.ReadAll(res.Body)
+		if err != nil {
+			return fmt.Errorf("read response error: %s", err.Error())
+		}
+
+		return fmt.Errorf("bad response status: %d, response: %s", res.StatusCode, string(bodyBytes))
+	}
+
+	return nil
 }


### PR DESCRIPTION
Being able to create stubs manually is great, but when you work with the SDK of a SAAS, you are not supposed to know what goes on the wire. Being able to record that, put it under version control and be done with it allows to remove that information from tests and focus on functional assertions.

Note: I've tried writing a `testcontainers`-based test for this, but quickly ran into an import cycle. Let me know if you can think of a way to test this properly. 


## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
