### PR TITLE
Add transformer parameters support in response handling

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -154,6 +154,16 @@ func TestStubRule_ToJson(t *testing.T) {
 				WillReturnResponse(OK()),
 			ExpectedFileName: "url-path-templating.json",
 		},
+		{
+			Name: "StubRuleWithScenarioWithTransformerParameters",
+			StubRule: Get(URLPathTemplate("/templated")).
+				WillReturnResponse(
+					NewResponse().
+						WithStatus(http.StatusOK).
+						WithTransformers("response-template").
+						WithTransformerParameter("MyCustomParameter", "Parameter Value")),
+			ExpectedFileName: "expected-template-transformerParameters.json",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/response.go
+++ b/response.go
@@ -19,15 +19,17 @@ type ResponseInterface interface {
 }
 
 type Response struct {
-	body                *string
-	base64Body          []byte
-	bodyFileName        *string
-	jsonBody            interface{}
-	headers             map[string]string
-	status              int64
-	delayDistribution   DelayInterface
-	chunkedDribbleDelay *chunkedDribbleDelay
-	fault               *Fault
+	body                  *string
+	base64Body            []byte
+	bodyFileName          *string
+	jsonBody              interface{}
+	headers               map[string]string
+	status                int64
+	delayDistribution     DelayInterface
+	chunkedDribbleDelay   *chunkedDribbleDelay
+	fault                 *Fault
+	transformers          []string
+	transformerParameters map[string]string
 }
 
 func NewResponse() Response {
@@ -126,6 +128,29 @@ func (r Response) WithBodyFile(fileName string) Response {
 	return r
 }
 
+// WithTransformers sets transformers for response
+func (r Response) WithTransformers(transformers ...string) Response {
+	r.transformers = transformers
+	return r
+}
+
+// WithTransformerParameter sets transformer parameters for response
+func (r Response) WithTransformerParameter(key, value string) Response {
+	if r.transformerParameters == nil {
+		r.transformerParameters = make(map[string]string)
+	}
+
+	r.transformerParameters[key] = value
+
+	return r
+}
+
+// WithTransformerParameters sets transformer parameters for response
+func (r Response) WithTransformerParameters(transformerParameters map[string]string) Response {
+	r.transformerParameters = transformerParameters
+	return r
+}
+
 func (r Response) ParseResponse() map[string]interface{} {
 	jsonMap := map[string]interface{}{
 		"status": r.status,
@@ -161,6 +186,14 @@ func (r Response) ParseResponse() map[string]interface{} {
 
 	if r.fault != nil {
 		jsonMap["fault"] = *r.fault
+	}
+
+	if r.transformers != nil {
+		jsonMap["transformers"] = r.transformers
+	}
+
+	if r.transformerParameters != nil {
+		jsonMap["transformerParameters"] = r.transformerParameters
 	}
 
 	return jsonMap

--- a/testdata/expected-template-transformerParameters.json
+++ b/testdata/expected-template-transformerParameters.json
@@ -1,0 +1,15 @@
+{
+  "uuid": "%s",
+  "id": "%s",
+  "request" : {
+    "method": "GET",
+    "urlPathTemplate" : "/templated"
+  },
+  "response" : {
+    "status" : 200,
+    "transformers": ["response-template"],
+    "transformerParameters": {
+      "MyCustomParameter": "Parameter Value"
+    }
+  }
+}


### PR DESCRIPTION

## Adds Transformer Parameter Support  

This PR implements the **Transformer Parameter** feature, as documented in the [WireMock response templating guide](https://wiremock.org/docs/response-templating/#using-transformer-parameters).  

The change enables dynamic parameter usage in response templates, improving flexibility for customized mock responses.  

### Key Benefits  
- Supports custom parameters in response templates  
- Enables finer control over dynamic responses in tests/mocks  
- Maintains compatibility with WireMock's core functionality  

### Usage Example  
```go  
stubRule := Get(URLPathTemplate("/templated")).  
    WillReturnResponse(  
        NewResponse().  
            WithStatus(http.StatusOK).  
            WithTransformers("response-template").  
            WithTransformerParameter("MyCustomParameter", "Parameter Value"),  
    )  
```
